### PR TITLE
Optimise quotes system by implementing a cache in memory

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,5 +1,6 @@
 """Main script to define bot methods, and start the bot."""
 
+from collections import defaultdict
 from os import environ
 
 from discord import Game
@@ -21,6 +22,8 @@ bot = Bot(
 bot.muted = []
 
 bot.banned_ids = []
+
+bot.quotes = defaultdict(list)
 
 
 @bot.check

--- a/bot/cogs/fun.py
+++ b/bot/cogs/fun.py
@@ -9,15 +9,15 @@ from typing import AsyncGenerator
 from urllib.parse import urlencode
 
 from aiohttp import ClientSession
-from discord import Embed, File, Message
+from discord import Embed, File, Member, Message
 from discord.ext.commands import (
-    Bot, Context, MemberConverter, TextChannelConverter, command, has_any_role
+    Bot, Context, TextChannelConverter, command, has_any_role
 )
 from wand.drawing import Drawing
 from wand.image import Image
 
 
-from bot.constants import ADMIN_ROLES, EMOJI_LETTERS, QUOTES_CHANNEL_ID
+from bot.constants import ADMIN_ROLES, EMOJI_LETTERS, QUOTES_BOT_ID, QUOTES_CHANNEL_ID
 
 
 EMOJI_LETTERS = [
@@ -60,6 +60,11 @@ class Fun:
         self.quote_channel = None
 
     async def on_message(self, message: Message):
+
+        if message.channel.id == QUOTES_CHANNEL_ID and message.author.id == QUOTES_BOT_ID:
+            author = message.embeds[0].title
+            self.bot.quotes[author].append(message.id)
+
         """
         React based on the contents of a message.
         """
@@ -183,39 +188,25 @@ class Fun:
         await ctx.send(embed=comic)
 
     @command()
-    async def quotes(self, ctx: Context, member: MemberConverter = None):
+    async def quotes(self, ctx: Context, member: Member = None):
         """
         Returns a random quotation from the #quotes channel.
         A user can be specified to return a random quotation from that user.
-        A #quotes channel must be set using the set_quote_channel command in order for this command to work.
         """
-        if self.quote_channel is None:
-            self.quote_channel = self.bot.get_channel(QUOTES_CHANNEL_ID)
-        quotation_channel = self.quote_channel
-        if member is not None:
-            quotations = []
-            async for quotation in quotation_channel.history(limit=None):
-                if len(quotation.embeds) > 0:
-                    embed = quotation.embeds[0]
-                    author_name = embed.author.name
-                    author = ctx.message.guild.get_member_named(author_name)
-                    if author == member:
-                        quotations.append(quotation)
-                elif member in quotation.mentions:
-                    quotations.append(quotation)
+        quote_channel = self.bot.get_channel(QUOTES_CHANNEL_ID)
+        quotes = self.bot.quotes
+
+        if member is None:
+            message_id = choice(quotes[choice(list(quotes.keys()))])
         else:
-            quotations = await quotation_channel.history(limit=None).flatten()
-        if len(quotations) > 0:
-            quotation = choice(quotations)
-            if len(quotation.embeds) > 0:
-                embed_quotation = quotation.embeds[0]
-                await ctx.send(embed=embed_quotation)
-            # Some quotes don't have embeds, let's try to show those too...
-            else:
-                # Send the quote with mentions removed and channel names parsed.
-                await ctx.send(content=quotation.clean_content)
-        else:
-            await ctx.send(content="No quotes found to display. Why not add some?")
+            user_quotes = quotes[f'{member.name}#{member.discriminator}']
+            if not user_quotes:
+                await ctx.send("No quotes from that user.")
+                return
+            message_id = choice(user_quotes)
+
+        message = await quote_channel.get_message(message_id)
+        await ctx.send(embed=message.embeds[0])
 
     @command()
     @has_any_role(*ADMIN_ROLES)

--- a/bot/cogs/general.py
+++ b/bot/cogs/general.py
@@ -1,4 +1,7 @@
+from discord import Message
 from discord.ext.commands import Bot
+
+from bot.constants import QUOTES_BOT_ID, QUOTES_CHANNEL_ID
 
 
 class General:
@@ -14,6 +17,17 @@ class General:
         print(self.bot.user.name)
         print(self.bot.user.id)
         print('------')
+
+        quote_channel = self.bot.get_channel(QUOTES_CHANNEL_ID)
+
+        def is_quote(message: Message):
+            return message.author.id == QUOTES_BOT_ID
+
+        async for quote in quote_channel.history(limit=None).filter(is_quote):
+            if not len(quote.embeds):
+                continue
+            author = quote.embeds[0].author.name
+            self.bot.quotes[author].append(quote.id)
 
 
 def setup(bot):

--- a/bot/cogs/general.py
+++ b/bot/cogs/general.py
@@ -24,7 +24,7 @@ class General:
             return message.author.id == QUOTES_BOT_ID
 
         async for quote in quote_channel.history(limit=None).filter(is_quote):
-            if not len(quote.embeds):
+            if not quote.embeds:
                 continue
             author = quote.embeds[0].author.name
             self.bot.quotes[author].append(quote.id)

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -3,6 +3,7 @@ A list of constants.
 """
 # Fun constants
 QUOTES_CHANNEL_ID = 463657120441696256
+QUOTES_BOT_ID = 292953664492929025
 
 # Lists for administration
 


### PR DESCRIPTION
Currently, the quotes command searches the entire history of the quotes channel every time someone runs :quotes, this PR implements an in memory cache so the command is much faster. This was originally going to be a SQLite database but Aperture and I decided it would be too much effort for too little performance payoff compared to this.