### PR TITLE
Check if word is plural instead of using "(s)"

### DIFF
--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -200,15 +200,15 @@ class Cyber:
         def suffix_from_number(num):
             return "" if num == 1 else "s"
 
-        monthOrMonths = "month" + suffix_from_number(time_until_game.months)
-        dayOrDays = "day" + suffix_from_number(time_until_game.days)
+        month_or_months = "month" + suffix_from_number(time_until_game.months)
+        day_or_days = "day" + suffix_from_number(time_until_game.days)
 
         if today > game_start_date:
             await ctx.send("Cyberstart Game has begun! Use :level base level to get info"
                            "on specific challenges once we update the bot")
             return
         await ctx.send("Cyberstart Game begins on the 15th January 2019.")
-        await ctx.send(f"That's in {time_until_game.months} {monthOrMonths} and {time_until_game.days} {dayOrDays}!")
+        await ctx.send(f"That's in {time_until_game.months} {month_or_months} and {time_until_game.days} {day_or_days}!")
 
     async def on_message(self, message: Message):
 

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -194,12 +194,21 @@ class Cyber:
         today = datetime.date.today()
         game_start_date = datetime.date(2019, 1, 15)
         time_until_game = relativedelta(game_start_date, today)
+        
+        # Given a number of items, determine whether it should be pluralised.
+        # Then, return the suffix of 's' if it should be, and '' if it shouldn't.
+        def suffix_from_number(num):
+            return "" if num == 1 else "s"
+        
+        monthOrMonths = "month" + suffix_from_number(time_until_game.months)
+        dayOrDays = "day" + suffix_from_number(time_until_game.days)
+        
         if today > game_start_date:
             await ctx.send("Cyberstart Game has begun! Use :level base level to get info"
                            "on specific challenges once we update the bot")
             return
         await ctx.send("Cyberstart Game begins on the 15th January 2019.")
-        await ctx.send(f"That's in {time_until_game.months} month(s) and {time_until_game.days} day(s)!")
+        await ctx.send(f"That's in {time_until_game.months} {monthOrMonths} and {time_until_game.days} {dayOrDays}!")
 
     async def on_message(self, message: Message):
 

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -200,15 +200,15 @@ class Cyber:
         def suffix_from_number(num):
             return "" if num == 1 else "s"
 
-        month_or_months = "month" + suffix_from_number(time_until_game.months)
-        day_or_days = "day" + suffix_from_number(time_until_game.days)
+        month_or_s = "month" + suffix_from_number(time_until_game.months)
+        day_or_s = "day" + suffix_from_number(time_until_game.days)
 
         if today > game_start_date:
             await ctx.send("Cyberstart Game has begun! Use :level base level to get info"
                            "on specific challenges once we update the bot")
             return
         await ctx.send("Cyberstart Game begins on the 15th January 2019.")
-        await ctx.send(f"That's in {time_until_game.months} {month_or_months} and {time_until_game.days} {day_or_days}!")
+        await ctx.send(f"That's in {time_until_game.months} {month_or_s} and {time_until_game.days} {day_or_s}!")
 
     async def on_message(self, message: Message):
 

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -209,15 +209,24 @@ class Cyber:
         def suffix_from_number(num):
             return "" if num == 1 else "s"
 
-        month_or_s = "month" + suffix_from_number(time_until_game.months)
-        day_or_s = "day" + suffix_from_number(time_until_game.days)
+        month_or_months = "month" + suffix_from_number(time_until_game.months)
+        day_or_days = "day" + suffix_from_number(time_until_game.days)
+        
+        month_countdown = f"{time_until_game.months} {month_or_months}"
+        day_countdown = f"{time_until_game.days} {day_or_days}"
+
+        # Diable the months component of the countdown when there are no months left
+        if time_until_game.months:
+            month_and_day_countdown = f"{month_countdown} and {day_countdown}"
+        else:
+            month_and_day_countdown = day_countdown
 
         if today > game_start_date:
             await ctx.send("Cyberstart Game has begun! Use :level base level to get info"
                            "on specific challenges once we update the bot")
             return
         await ctx.send("Cyberstart Game begins on the 15th January 2019.")
-        await ctx.send(f"That's in {time_until_game.months} {month_or_s} and {time_until_game.days} {day_or_s}!")
+        await ctx.send(f"That's in {month_and_day_countdown}!")
 
     async def on_message(self, message: Message):
 

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -194,15 +194,15 @@ class Cyber:
         today = datetime.date.today()
         game_start_date = datetime.date(2019, 1, 15)
         time_until_game = relativedelta(game_start_date, today)
-        
+
         # Given a number of items, determine whether it should be pluralised.
         # Then, return the suffix of 's' if it should be, and '' if it shouldn't.
         def suffix_from_number(num):
             return "" if num == 1 else "s"
-        
+
         monthOrMonths = "month" + suffix_from_number(time_until_game.months)
         dayOrDays = "day" + suffix_from_number(time_until_game.days)
-        
+
         if today > game_start_date:
             await ctx.send("Cyberstart Game has begun! Use :level base level to get info"
                            "on specific challenges once we update the bot")

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -211,7 +211,7 @@ class Cyber:
 
         month_or_months = "month" + suffix_from_number(time_until_game.months)
         day_or_days = "day" + suffix_from_number(time_until_game.days)
-        
+
         month_countdown = f"{time_until_game.months} {month_or_months}"
         day_countdown = f"{time_until_game.days} {day_or_days}"
 


### PR DESCRIPTION
Before, the bot was not checking if the word 'month' or 'day' needed to be pluralised when informing the user of the days and months until the CyberDiscovery competition 'game', so it would append "(s)" to the end of the word to account for both cases. However, this makes the bot seem less human, because people tailor their messages depending on the pluralisation of the words they use.

Given that we needed to check for pluralisation in two places, and use the same suffix in both cases, it seemed intuitive to create a function which we could invoke twice. As I am unfamiliar with the codebase, it would be helpful to know if this should perhaps be defined in the global scope; or even in a file designed just for utility functions, because I could imagine this function being quite reusable.

This commit was made using the online interface due to me being away from my normal development computer. If there are formatting issues, I will correct them in a subsequent commit.

**The proposed code in this pull request is untested, and I am unable to test it for the near future, but have decided to file this pull request anyway because the code changes within it are minimal**

***EDIT***: A new feature was commited to this pull request. If the 'months' component is 0, don't show it.