### PR TITLE
Fix Assess Regex

### DIFF
--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -19,7 +19,7 @@ class Cyber:
     def __init__(self, bot: Bot):
         self.bot = bot
         self.assess_regex = re.compile(
-            r"^.*\assess\b.*(end|finish|close)\b.*$",
+            r"^.*\bassess\b.*(end|finish|close)\b.*$",
             re.IGNORECASE
         )
         self.game_regex = re.compile(


### PR DESCRIPTION
There was an `\b` missing in the assess regex. This commit fixes the issue and now correctly recognises the string