### PR TITLE
Prevent bot responding to a command

### DIFF
--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -271,6 +271,9 @@ class Cyber:
         await ctx.send(f"That's in {month_and_day_countdown}!")
 
     async def on_message(self, message: Message):
+        ctx = await self.bot.get_context(message)
+        if ctx.valid:
+            return
 
         # CyberStart Assess Dates.
         if self.assess_start_regex.match(message.content):


### PR DESCRIPTION
Checks if a valid command context exists before automatically responding to messages. Same functionality as #96 and #97 (btw does anyone know why #96 was closed?) but more maintainable as the prefix isn't hardcoded.