### PR TITLE
Refactor the ":game" and ":essentials" commands so that they both point to the same code

### DIFF
--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -212,10 +212,18 @@ class Cyber:
 
     @command()
     async def game(self, ctx: Context):
+        """
+        Gets the date of, and days and months until, CyberStart Game
+        """
+
         await self.countdown('15th January 2019', 'CyberStart Game', ctx)
 
     @command()
     async def essentials(self, ctx: Context):
+        """
+        Gets the date of, and days and months until, CyberStart Essentials
+        """
+
         await self.countdown('5th March 2019', 'CyberStart Essentials', ctx)
 
     async def countdown(self, countdown_target_str: str, stage_name: str, ctx: Context):


### PR DESCRIPTION
Previously, the `game` and `essentials` commands had a copy of the same logic in their implementations. This means that making changes to that logic requires changing two things. This reduces developer efficiency and can lead to mistakes.

This pull request abstracts away this logic into the `command` function. It takes the following parameters
- The string date -- used both in the output to the user, and also parsed into a `datetime.date` to become the target for the countdown
- The name of the stage ("CyberStart Essentials" or "CyberStart Game")
- The context

This pull request was tested in the following way:
- Run the bot locally on a private server
- Observe that `:game` produces the same output as before
- Observe that `:essentials` produces the same output as before

This pull request only refactors code, and does not change behaviour for the end-user. 