### PR TITLE
Show a warning when requesting an assess challenge >8

### DIFF
--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -119,6 +119,9 @@ class Cyber:
         Gets information about a specific CyberStart Assess level and challenge.
         """
 
+        HINTS_LIMIT = 8  # Challenge number up to where hints are allowed (inclusive)
+        NO_HINTS_MSG = f"**:warning: Remember, we can't give hints after challenge {HINTS_LIMIT}**"
+
         # Gather Assess data from JSON file.
         with open("bot/data/assess.json") as f:
             assess_docs = load(f)
@@ -132,6 +135,10 @@ class Cyber:
             challenge_title = challenge_raw["title"]
             challenge_difficulty = challenge_raw["difficulty"]
             challenge_text = challenge_raw["description"]
+
+            if challenge_num > HINTS_LIMIT:
+                challenge_text = NO_HINTS_MSG + '\n' + challenge_text
+
             embed = Embed(
                 title=f"CyberStart Assess Challenge {challenge_num} - {challenge_title}",
                 description=challenge_text,


### PR DESCRIPTION
The bot allows users to read the challenges of the CyberStart Assess stage using the `:assess` command. However, other users are not allowed to provide hints for challenges 9 through 14, so as to keep the competition fair.

Despite the #assess channel clearly asking users to read the pinned messages, as an extra barrier against people asking for hints, this pull request introduces a warning message. It looks like this:

> **:warning: Remember, we can't give hints after challenge 8**

It appears directly before the challenge description in the bot's response body, if a challenge number greater than 8 is requested.

The hints limit is placed in a variable so it can be easily updated in the future.

Here is a screenshot of the bot running.

![Responses to requests for challenge 9 include the warning](https://user-images.githubusercontent.com/18113170/51087230-61f45f00-1748-11e9-96e5-747f13b13799.png)

![Responses to requests for challenge 8 do not include the warning](https://user-images.githubusercontent.com/18113170/51087240-82241e00-1748-11e9-8d37-9a6c7949fd3a.png)
