### PR TITLE
Ensure that the :flag command always generates unique results; and add some validation to it.

### DIFF
--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -94,13 +94,10 @@ class Cyber:
         elif challenge_num == 0:
             await ctx.send("Invalid challenge number!")
             return
-        # Find out which base the user is refering to.
-        for area in BASE_ALIASES.keys():
-            if base.lower() in BASE_ALIASES[area]:
-                base = area
-                break
-        else:
-            await ctx.send("Unknown base.")
+
+        base = self.get_area_from_base_abbrv(base)
+
+        if base is None:
             return
 
         # Check to see if that many levels are present
@@ -138,7 +135,7 @@ class Cyber:
             # Generates random, but unique and identical per challenge, base 64 "flag"
             #
             # First, we must generate a numeric seed (deterministically) out of:
-            # - the base (HQ/Forensics/Moon)
+            # - the area [base] (HQ/Forensics/Moon)
             # - the level [1..13]
             # - the challenge [1..13]
             #
@@ -151,12 +148,13 @@ class Cyber:
             # gain a single numeric seed which we can then pass for further computation
             # to `generatebase64`
             #
-            # To convert the base (HQ/Forensics/Moon) into a number, we take the ASCII
+            # To convert the area (HQ/Forensics/Moon) into a number, we take the ASCII
             # value of the first character present. ("H", "F", and "M" respectively).
-            #
-            # TODO: Validate that only those bases (HQ/Forensics/Moon) are allowed
 
-            seed = ord(base[0].lower()), level_num, challenge_num
+            area = self.get_area_from_base_abbrv(base)
+
+            seed = ord(area[0]), level_num, challenge_num
+
             num_base = 128  # the positional number base to use (must be > than all components of seed)
 
             aggregate_seed = sum(digit * (num_base ** digit_index) for digit_index, digit in enumerate(seed))
@@ -340,6 +338,11 @@ class Cyber:
             return
         await ctx.send(f"{stage_name} begins on the {countdown_target_str}.\n"
                        f"That's in {month_and_day_countdown}!")
+
+    async def get_area_from_base_abbrv(self, base: str):
+        for area in BASE_ALIASES.keys():
+            if base.lower() in BASE_ALIASES[area]:
+                return area
 
     async def on_message(self, message: Message):
         # Check the current command context

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -136,7 +136,33 @@ class Cyber:
             content = "13.1 is a No Flag Zone™ 🙅⛔⚔️"
         else:
             # Generates random, but unique and identical per challenge, base 64 "flag"
-            content = "The flag is: " + await generatebase64(ord(base[0]) + level_num + challenge_num)
+            #
+            # First, we must generate a numeric seed (deterministically) out of:
+            # - the base (HQ/Forensics/Moon)
+            # - the level [1..13]
+            # - the challenge [1..13]
+            #
+            # If we just added up the components of the seed, the resulting seed would not
+            # be unique. For example, 2 + 2 + 2 = 1 + 2 + 3.
+            #
+            # As a result, we treat each component of the seed as a digit in a positional
+            # number system (in this case, base-128, since all components will be less than
+            # this value). We can then convert these components (digits) into base-10 and
+            # gain a single numeric seed which we can then pass for further computation
+            # to `generatebase64`
+            #
+            # To convert the base (HQ/Forensics/Moon) into a number, we take the ASCII
+            # value of the first character present. ("H", "F", and "M" respectively).
+            #
+            # TODO: Validate that only those bases (HQ/Forensics/Moon) are allowed
+            # TODO: Ensure that capital and lowercase letters both result in the same flag
+
+            seed = ord(base[0]), level_num, challenge_num
+            num_base = 128  # the positional number base to use (must be > than all components of seed)
+
+            aggregate_seed = sum(digit * (num_base ** digit_index) for digit_index, digit in enumerate(seed))
+
+            content = "The flag is: " + await generatebase64(aggregate_seed)
 
         embed = Embed(
             title=(f"{base} - Level {level_num} Challenge {challenge_num}"),

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -155,7 +155,6 @@ class Cyber:
             # To convert the area (HQ/Forensics/Moon) into a number, we take the ASCII
             # value of the first character present. ("H", "F", and "M" respectively).
 
-
             seed = ord(area[0]), level_num, challenge_num
 
             num_base = 128  # the positional number base to use (must be > than all components of seed)

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -95,7 +95,7 @@ class Cyber:
             await ctx.send("Invalid challenge number!")
             return
 
-        base = await self.get_area_from_base_abbrv(base)
+        base = self.get_area_from_base_abbrv(base)
 
         if base is None:
             return
@@ -129,7 +129,7 @@ class Cyber:
     @command()
     async def flag(self, ctx: Context, base: str, level_num: int, challenge_num: int = 0):
         """Generate a flag for the specified base, level and challenge."""
-        area = await self.get_area_from_base_abbrv(base)
+        area = self.get_area_from_base_abbrv(base)
 
         if level_num == 13 and challenge_num == 1:
             content = "13.1 is a No Flag Zone™ 🙅⛔⚔️"
@@ -342,7 +342,7 @@ class Cyber:
         await ctx.send(f"{stage_name} begins on the {countdown_target_str}.\n"
                        f"That's in {month_and_day_countdown}!")
 
-    async def get_area_from_base_abbrv(self, base: str):
+    def get_area_from_base_abbrv(self, base: str):
         for area in BASE_ALIASES.keys():
             if base.lower() in BASE_ALIASES[area]:
                 return area

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -133,9 +133,9 @@ class Cyber:
             challenge_num = level_num
             level_num = int(base)
             base = "Headquarters"
-        
+
         area = self.get_area_from_base_abbrv(base)
-        
+
         if level_num == 13 and challenge_num == 1:
             content = "13.1 is a No Flag Zone™ 🙅⛔⚔️"
         elif area is None:

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -342,7 +342,8 @@ class Cyber:
         await ctx.send(f"{stage_name} begins on the {countdown_target_str}.\n"
                        f"That's in {month_and_day_countdown}!")
 
-    def get_area_from_base_abbrv(self, base: str):
+    @staticmethod
+    def get_area_from_base_abbrv(base: str):
         for area in BASE_ALIASES.keys():
             if base.lower() in BASE_ALIASES[area]:
                 return area

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -155,9 +155,8 @@ class Cyber:
             # value of the first character present. ("H", "F", and "M" respectively).
             #
             # TODO: Validate that only those bases (HQ/Forensics/Moon) are allowed
-            # TODO: Ensure that capital and lowercase letters both result in the same flag
 
-            seed = ord(base[0]), level_num, challenge_num
+            seed = ord(base[0].lower()), level_num, challenge_num
             num_base = 128  # the positional number base to use (must be > than all components of seed)
 
             aggregate_seed = sum(digit * (num_base ** digit_index) for digit_index, digit in enumerate(seed))

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -153,9 +153,10 @@ class Cyber:
             # to `generatebase64`
             #
             # To convert the area (HQ/Forensics/Moon) into a number, we take the ASCII
-            # value of the first character present. ("H", "F", and "M" respectively).
+            # value of each character in the canonical form of the area name, and treat
+            # each one as a digit of the base-128 number.
 
-            seed = ord(area[0]), level_num, challenge_num
+            seed = *map(ord, area), level_num, challenge_num
 
             num_base = 128  # the positional number base to use (must be > than all components of seed)
 

--- a/bot/cogs/cyber.py
+++ b/bot/cogs/cyber.py
@@ -95,7 +95,7 @@ class Cyber:
             await ctx.send("Invalid challenge number!")
             return
 
-        base = self.get_area_from_base_abbrv(base)
+        base = await self.get_area_from_base_abbrv(base)
 
         if base is None:
             return
@@ -129,8 +129,12 @@ class Cyber:
     @command()
     async def flag(self, ctx: Context, base: str, level_num: int, challenge_num: int = 0):
         """Generate a flag for the specified base, level and challenge."""
+        area = await self.get_area_from_base_abbrv(base)
+
         if level_num == 13 and challenge_num == 1:
             content = "13.1 is a No Flag Zone™ 🙅⛔⚔️"
+        elif area is None:
+            content = "Error: Invalid base specified"
         else:
             # Generates random, but unique and identical per challenge, base 64 "flag"
             #
@@ -151,7 +155,6 @@ class Cyber:
             # To convert the area (HQ/Forensics/Moon) into a number, we take the ASCII
             # value of the first character present. ("H", "F", and "M" respectively).
 
-            area = self.get_area_from_base_abbrv(base)
 
             seed = ord(area[0]), level_num, challenge_num
 


### PR DESCRIPTION
Consider these two commands

```
:flag HQ 1 13
:flag HQ 2 12
```

Previously, these would generate the same flag. This is because the algorithm for determining a seed for the random number generator was this: `H + 1 + 13`. This is the same as `H + 2 + 12` because they both sum to `H + 14`.

The new algorithm is to consider the base-128 number with the digits `H, 1, 13` (and `H, 2, 12`). These are then converted into base 10. This guarantees uniqueness because all components will be less than 128.

*see bottom section, the actual new algorithm includes more than just the first letter
<hr>

Consider these two commands

```
:flag HQ 1 13
:flag hq 1 13
```

These would previously generate different flags, even though they are referring to the same challenge. This is because the sum `H + 1 + 13` is different to `h + 1 + 13`, as `H` and `h` have different ASCII codes.

So we create a new function which takes existing logic which we can reuse here. We call this function `get_area_from_base_abbrv`. It takes in something like `f` or `python` or `moon` or `hq` and outputs a canonical value (`Headquaters`, `Moonbase`, `Forensics`). This forces the first letter to be uppercase as a side-effect, which resolves this issue

<hr>

~~One thing we are assuming here which makes the code brittle is that all the bases have different initial letters (`H`, `M`, and `F`). Ideally, we would use every single letter of the base so that if, in future, something changes, we can still have unique flags.~~

Every single letter is now a digit of the base-128 number, so that `Headquarters` and `Hacking` bases (latter is fictitious) will result in different flags.