### PR TITLE
Allow self assignable roles

### DIFF
--- a/bot/cogs/general.py
+++ b/bot/cogs/general.py
@@ -34,7 +34,9 @@ class General:
         role_name = SELF_ROLE_NAMES.get(year_group, None)
 
         if role_name is None:
-            await ctx.send(f"Not a self-assignable role. Try one of: {', '.join(SELF_ROLE_NAMES.keys())}")
+            msg = f"Not a self-assignable role. Try one of: {', '.join(SELF_ROLE_NAMES.keys())}, "
+            msg += "or use 'remove' if you don't want a year group role"
+            await ctx.send(msg)
         else:
             roles_to_add = list(filter(lambda role: role.name == role_name, ctx.guild.roles))
 

--- a/bot/cogs/general.py
+++ b/bot/cogs/general.py
@@ -1,7 +1,7 @@
 from discord import Message
-from discord.ext.commands import Bot
+from discord.ext.commands import Bot, BucketType, Context, command, cooldown
 
-from bot.constants import QUOTES_BOT_ID, QUOTES_CHANNEL_ID
+from bot.constants import QUOTES_BOT_ID, QUOTES_CHANNEL_ID, SELF_ROLE_NAMES
 
 
 class General:
@@ -11,6 +11,37 @@ class General:
 
     def __init__(self, bot: Bot):
         self.bot = bot
+
+    @cooldown(rate=1, per=5, type=BucketType.user)
+    @command(aliases=["y"])
+    async def year(self, ctx: Context, year_group: str):
+        """
+        Self-assigns a role to the user based on their year group, e.g. :year 11
+
+        Use ":year old" if no longer in secondary education
+        Use ":year remove" to remove all self-assignable roles
+
+        Rate limited to one use per five seconds per user
+        """
+        year_group = year_group.lower()
+        roles_to_remove = list(filter(lambda role: role.name in SELF_ROLE_NAMES.values(), ctx.guild.roles))
+
+        if year_group == "remove":
+            await ctx.author.remove_roles(*roles_to_remove)
+            await ctx.send("All self-assignable roles removed successfully")
+            return
+
+        role_name = SELF_ROLE_NAMES.get(year_group, None)
+
+        if role_name is None:
+            await ctx.send(f"Not a self-assignable role. Try one of: {', '.join(SELF_ROLE_NAMES.keys())}")
+        else:
+            roles_to_add = list(filter(lambda role: role.name == role_name, ctx.guild.roles))
+
+            await ctx.author.remove_roles(*roles_to_remove)
+            await ctx.author.add_roles(*roles_to_add)
+
+            await ctx.send("Role assigned successfully.")
 
     async def on_ready(self):
         print('Logged in as')

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -6,6 +6,15 @@ QUOTES_CHANNEL_ID = 463657120441696256
 QUOTES_BOT_ID = 292953664492929025
 LOGGING_CHANNEL_ID = 538494690601992212
 
+# Self-assignable roles
+SELF_ROLE_NAMES = {
+    "10": "Year 10",
+    "11": "Year 11",
+    "12": "Year 12",
+    "13": "Year 13",
+    "old": "Always just a bit too old"
+}
+
 # Lists for administration
 
 ADMIN_ROLES = ("Root", "Sudo")


### PR DESCRIPTION
The current command `?add-role "Year X"` is broken. This is likely because you have to actually @mention the role -- which would lead to a lot of unwanted notifications from that year group.

Instead, we introduce the `:year` command. It is rate limited to 1 request per 5 seconds per user. This is because setting a year group is usually a fairly infrequent action (once a year, ideally); and there is a rate limit from Discord's side in place I think.

In the constants file, there's a dictionary containing all the role names ("Year 1[0123]", "Always just a bit too old"). These are the roles which are self-assignable.

The following commands work:

```
# As you'd expect
:year 10
:year 11
:year 12
:year 13

# Always just a bit too old
:year old

# Remove year-group role
:year remove
```

The command is case-insensitive, and validates its input (if invalid year group, all possible year groups listed), but throws an error if a role does not exist in the guild.

The documentation in the #readme channel will need to be updated if this is merged

<hr>

![Screenshot of the bot responding to requests for year 10, 14 (which resulted in an error message), and year old -- and the 'd' in old is capitalized to show that the command is case-insensitive](https://user-images.githubusercontent.com/18113170/52169697-b5990d80-2734-11e9-913d-9a0c993f4cce.png)
