### PR TITLE
Implemented BytesIO for image generation

### DIFF
--- a/bot/cogs/fun.py
+++ b/bot/cogs/fun.py
@@ -2,6 +2,7 @@
 Set of bot commands designed for general leisure.
 """
 import textwrap
+from io import BytesIO
 from random import choice, randint
 from string import ascii_lowercase
 from typing import AsyncGenerator
@@ -226,8 +227,12 @@ class Fun:
             draw.text(image.width // 5 + 20, image.height // 5 + offset, line)
             offset += 35
         draw(image)
-        image.save(filename=f"bot/resources/{person}Says.png")
-        await ctx.send(file=File(f"bot/resources/{person}Says.png"))
+        image_bytes = BytesIO()
+        image.save(image_bytes)
+        image_bytes.seek(0)
+        await ctx.send(
+            file=File(image_bytes, filename=f'{person}.png')
+        )
 
     @command()
     async def agentj(self, ctx: Context, *, text: str):


### PR DESCRIPTION
This PR just changes the image generation command so that it uses an `io.BytesIO` object to write (and send) the image, rather than saving it to disk. This is a better approach for several reasons:

- Commands that are executed asynchronously display **only the image that was requested**. With the previous approach, this was not guaranteed since these images are saved to disk with the same filename.
- There are no longer any files saved to disk, meaning issues with the staging area (such as #134) are resolved.
- The command is marginally faster, as it is no longer blocked by disk r/w speeds.

resolves #134 