### PR TITLE
Remove Codacy Badge From Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cyber Discovery Discord Bot [![Build Status](https://travis-ci.com/CyberDiscovery/cyberdisc-bot.svg?branch=master)](https://travis-ci.com/CyberDiscovery/cyberdisc-bot) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c23486f81ee7451eb66405f01591b586)](https://www.codacy.com/app/CyberDiscovery/cyberdisc-bot?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=CyberDiscovery/cyberdisc-bot&amp;utm_campaign=Badge_Grade) [![Discord](https://discordapp.com/api/guilds/409851296116375565/embed.png)](https://discord.gg/AQPh34Y)
+# Cyber Discovery Discord Bot [![Build Status](https://travis-ci.com/CyberDiscovery/cyberdisc-bot.svg?branch=master)](https://travis-ci.com/CyberDiscovery/cyberdisc-bot) [![Discord](https://discordapp.com/api/guilds/409851296116375565/embed.png)](https://discord.gg/AQPh34Y)
 The bot for the Cyber Discovery Community Discord Server!
 
 ## Installation


### PR DESCRIPTION
Remove the Codacy badge from README.md, as Codacy has been removed from the repo due to lack of use.