### PR TITLE
Fix path to assess.json

### DIFF
--- a/cdbot/cogs/cyber.py
+++ b/cdbot/cogs/cyber.py
@@ -85,7 +85,7 @@ class Cyber(Cog):
             return
 
         # Gather data from CyberStart Game.
-        with open("bot/data/game.json") as f:
+        with open("cdbot/data/game.json") as f:
             game_docs = load(f)
         # Temporary change to allow old usage method
         if base.isnumeric():


### PR DESCRIPTION
The path to `assess.json` was not fixed when we changed the directory name.
Thanks @Sh3llcod3 for bringing it to our attention.