### PR TITLE
Improved commit summary

### DIFF
--- a/cdbot/cogs/general.py
+++ b/cdbot/cogs/general.py
@@ -1,8 +1,8 @@
 from discord.ext.commands import Bot, Cog
 from git import Repo
 
-
-commit = Repo().commit()
+repo = Repo()
+latest = repo.commit()
 
 
 class General(Cog):
@@ -19,11 +19,13 @@ class General(Cog):
         print(self.bot.user.name)
         print(self.bot.user.id)
         print("------")
-        date = commit.authored_datetime.strftime('**%x** at **%X**')
+        message, *_ = latest.message.partition('\n')
+        link = f'{next(repo.remote().urls)}/commit/{latest}'
+        date = latest.authored_datetime.strftime('**%x** at **%X**')
         self.bot.log.info(
             "CyberDiscovery bot is now logged in.\n"
-            f"Latest commit: **[{commit}](https://github.com/CyberDiscovery/cyberdisc-bot/commit/{commit})**"
-            f"\nAuthor: **{commit.author}** on {date}"
+            f"Latest commit: **[{message}]({link})**"
+            f"\nAuthor: **{latest.author}** on {date}"
         )
 
     @Cog.listener()


### PR DESCRIPTION
Replaces what was previously the commit hash in the embed. Now it contains the title of the latest commit.

![image](https://user-images.githubusercontent.com/25161069/55558177-68f59280-56e3-11e9-856b-6f5346975093.png)
