### PR TITLE
Added docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+volumes:
+
+  database:
+    driver: local
+
+
+services:
+
+  database:
+    image: postgres:latest
+    volumes:
+      - database:/var/lib/postgresql/data
+
+  bot:
+    build: .
+    links:
+      - database
+    environment:
+      - PGHOST=database
+      - PGUSER=postgres
+      - PGDATABASE=postgres
+      - BOT_TOKEN
+      - QUOTES_BOT_ID
+      - QUOTES_CHANNEL_ID
+      - LOGGING_CHANNEL_ID
+


### PR DESCRIPTION
Added a docker-compose configuration, to make it easier to test the quotes and database systems locally.

![image](https://user-images.githubusercontent.com/25161069/55561497-2aafa180-56ea-11e9-885e-2713e2d19ac3.png)

The docker compose configuration pulls the latest postgres image automatically, links it to the bot image and starts both. This lets us test database-level operations without needing to set up postgres locally.