### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Copy the token (you need to click to reveal it) and set it as an environment var
 ```
 export BOT_TOKEN="<insert bot token here>"
 ```
-You may want to add this line to your .bashrc or similar to preserve it over terminal windows and sessions.
-
+Or on Windows:
+```
+set BOT_TOKEN="<insert bot token here>"
+```
 Go back to the home page of your application on discord and grab the client ID. Then put it into this url:
 ```
 https://discordapp.com/oauth2/authorize?&client_id=<insert client id here>&scope=bot&

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Or on Windows:
 ```
 set BOT_TOKEN="<insert bot token here>"
 ```
-Go back to the home page of your application on discord and grab the client ID. Then put it into this url:
+Go back to the home page of your application on Discord and grab the client ID. Then put it into this url:
 ```
 https://discordapp.com/oauth2/authorize?&client_id=<insert client id here>&scope=bot&
 ```


### PR DESCRIPTION
Added instructions on how to set the BOT_TOKEN environment variable on windows, and removed the recommendation of inserting the bot token in a .bashrc, as credentials should not be stored in customization files that are frequently uploaded to public repositories (as part of a dotfiles collection).