### PR TITLE
Suppress some errors

### DIFF
--- a/cdbot/cogs/general.py
+++ b/cdbot/cogs/general.py
@@ -55,7 +55,6 @@ class General(Cog):
         else:
             await ctx.send("\N{NO ENTRY SIGN} An error occured during execution, the error has been reported.")
 
-
         self.bot.log.exception(error)
 
 

--- a/cdbot/cogs/general.py
+++ b/cdbot/cogs/general.py
@@ -32,10 +32,10 @@ class General(Cog):
     @Cog.listener()
     async def on_command_error(self, ctx, error):
         # Try provide some user feedback instead of logging all errors.
-        # 
+
         if isinstance(error, commands.CommandNotFound):
             return  # No need to log unfound commands anywhere or return feedback
-        
+
         if isinstance(error, commands.MissingRequiredArgument):
             # Missing arguments are likely human error so do not need logging
             parameter_name = error.param.name
@@ -43,20 +43,19 @@ class General(Cog):
         elif isinstance(error, commands.CheckFailure):
             return await ctx.send("\N{NO ENTRY SIGN} You do not have permission to use that command")
         elif isinstance(error, commands.CommandOnCooldown):
-            return await ctx.send(f"\N{HOURGLASS} That command is on cooldown, try again in {error.retry_after} seconds")
-        
+            return await ctx.send(f"\N{HOURGLASS} Command is on cooldown, try again after {error.retry_after} seconds")
+
         # All errors below this need reporting and so do not return
-        
+
         if isinstance(error, commands.ArgumentParsingError):
             # Provide feedback & report error
             await ctx.send("\N{NO ENTRY SIGN} An issue occurred while attempting to parse an argument")
         elif isinstance(error, commands.BadArgument):
             await ctx.send("\N{NO ENTRY SIGN} Conversion of an argument failed")
         else:
-            await ctx.send("\N{NO ENTRY SIGN} An error occured while executing that command, the error has been reported.")
-            
-        
-        
+            await ctx.send("\N{NO ENTRY SIGN} An error occured during execution, the error has been reported.")
+
+
         self.bot.log.exception(error)
 
 

--- a/cdbot/cogs/general.py
+++ b/cdbot/cogs/general.py
@@ -1,3 +1,4 @@
+from discord.ext import commands
 from discord.ext.commands import Bot, Cog
 from git import Repo
 
@@ -30,6 +31,32 @@ class General(Cog):
 
     @Cog.listener()
     async def on_command_error(self, ctx, error):
+        # Try provide some user feedback instead of logging all errors.
+        # 
+        if isinstance(error, commands.CommandNotFound):
+            return  # No need to log unfound commands anywhere or return feedback
+        
+        if isinstance(error, commands.MissingRequiredArgument):
+            # Missing arguments are likely human error so do not need logging
+            parameter_name = error.param.name
+            return await ctx.send(f"\N{NO ENTRY SIGN} Required argument {parameter_name} was missing")
+        elif isinstance(error, commands.CheckFailure):
+            return await ctx.send("\N{NO ENTRY SIGN} You do not have permission to use that command")
+        elif isinstance(error, commands.CommandOnCooldown):
+            return await ctx.send(f"\N{HOURGLASS} That command is on cooldown, try again in {error.retry_after} seconds")
+        
+        # All errors below this need reporting and so do not return
+        
+        if isinstance(error, commands.ArgumentParsingError):
+            # Provide feedback & report error
+            await ctx.send("\N{NO ENTRY SIGN} An issue occurred while attempting to parse an argument")
+        elif isinstance(error, commands.BadArgument):
+            await ctx.send("\N{NO ENTRY SIGN} Conversion of an argument failed")
+        else:
+            await ctx.send("\N{NO ENTRY SIGN} An error occured while executing that command, the error has been reported.")
+            
+        
+        
         self.bot.log.exception(error)
 
 


### PR DESCRIPTION
This adds some code so that errors which don't need reporting are not reported, but are instead given feedback from the bot in the channel at time of execution.

This surpasses:
- Command not found

Provides feedback and suppression for:
- Missing required arguments
- Check failures
- Cooldowns

Adds feedback but does not suppress:
- Argument parsing errors
- Bad argument errors
- All other exceptions
