### PR TITLE
Round the cooldown retry after

### DIFF
--- a/cdbot/cogs/general.py
+++ b/cdbot/cogs/general.py
@@ -48,7 +48,8 @@ class General(Cog):
         elif isinstance(error, commands.CheckFailure):
             return await ctx.send("\N{NO ENTRY SIGN} You do not have permission to use that command")
         elif isinstance(error, commands.CommandOnCooldown):
-            return await ctx.send(f"\N{HOURGLASS} Command is on cooldown, try again after {error.retry_after} seconds")
+            retry_after = round(error.retry_after)
+            return await ctx.send(f"\N{HOURGLASS} Command is on cooldown, try again after {retry_after} seconds")
 
         # All errors below this need reporting and so do not return
 


### PR DESCRIPTION
This PR just rounds the cooldown durations so that they aren't a horrifically long float.

Prevents this:
![](https://user-images.githubusercontent.com/25161069/56458801-0ce96a00-6383-11e9-99ee-3913b6c674e7.png)