### PR TITLE
Add more Elite stats: young, old, undisclosed

### DIFF
--- a/cdbot/cogs/cyber.py
+++ b/cdbot/cogs/cyber.py
@@ -377,7 +377,11 @@ class Cyber(Cog):
         exch_l_r = ctx.guild.get_role(ELITE_EXCH_LIST_ROLE_ID)
         exch_c_r = ctx.guild.get_role(ELITE_EXCH_CONF_ROLE_ID)
 
-        await ctx.send(f"""There are {len(elite_r.members)} server members that have qualified for CyberStart Elite.
+        elite_count = len(elite_r.members)
+        young_count = len(ldn_y_r.members) + len(brm_y_r.members) + len(lan_y_r.members)
+        old_count = len(ldn_o_r.members) + len(brm_o_r.members) + len(lan_o_r.members)
+
+        await ctx.send(f"""There are {elite_count} server members that have qualified for CyberStart Elite.
 {len(exch_l_r.members)} members have qualified for Exchange ({len(exch_c_r.members)} confirmed).
 
 Of those who didn't, preferences have been expressed as follows:
@@ -387,6 +391,11 @@ Birmingham - Younger: {len(brm_y_r.members)}
 Birmingham - Older: {len(brm_o_r.members)}
 Lancaster - Younger: {len(lan_y_r.members)}
 Lancaster - Older: {len(lan_o_r.members)}
+
+Total younger: {young_count}
+Total older: {old_count}
+
+There are {elite_count - (young_count + old_count)} server members who qualified but haven't told us their preferences
         """)
 
     async def countdown(self, countdown_target_str: str, stage_name: str, ctx: Context):


### PR DESCRIPTION
This adds some more statistics to the `:elitecount` command. The data points added are

#### Total young

This is the number of people who are going to Birmingham, Lancaster, or London in the 14-15 ("younger") age range. This does *not* take the symmetric difference of all three sets: instead, it just adds together the numbers for the three venues. This means that if somebody has the role for "Birmingham" and the role for "Lancaster" at the same time, they will be double-counted.

Could the server staff advise if this is every something which is done -- if so, perhaps taking the symmetric difference would be better.

#### Total old

Same as **total young**, but counts the people who have qualified for the "older" age group.

#### Undisclosed

This is the number of people who have the "Elite 2019" role, but do not have a role denoting the specific venue. This is useful information because it allows people to construct an upper and lower bound for each venue at any particular point in time

<hr>

This pull request is untested and therefore is being opened initially as a draft. However, given that the automated test suite seems to not error, I am upgrading this pull request to a proper one.