### PR TITLE
Block :react in #quotes

### DIFF
--- a/cdbot/cogs/fun.py
+++ b/cdbot/cogs/fun.py
@@ -247,6 +247,9 @@ class Fun(Cog):
         Emojifies a given string, and reacts to a previous message
         with those emojis.
         """
+        if ctx.channel.id == QUOTES_CHANNEL_ID:
+            await ctx.send("This command is disabled in this channel!", delete_after=10)
+            return
         limit, _, output = message.partition(" ")
         if limit.isdigit():
             limit = int(limit)


### PR DESCRIPTION
This should block `:react` in #quotes, which stops things like the attached image where people add random reaction messages to things in #quotes. ~~The theory with silently failing is that anyone who tries `:react` realises it fails, and can clean up their own message without needing a response from the bot cleaned up too.~~ Mentioned to Tref the other day, who suggested just diving in and making a PR. ~~Magic number used for the channel ID because I'm not aware of a quick and easy global configuration method.~~

![image](https://user-images.githubusercontent.com/7524553/76296086-9496da80-62ad-11ea-9db5-dbd94e63fb59.png)
