### PR TITLE
Make LaTeX renderer less spammable

### DIFF
--- a/cdbot/cogs/maths.py
+++ b/cdbot/cogs/maths.py
@@ -114,7 +114,8 @@ class Maths(Cog):
     @Cog.listener()
     async def on_message(self, message):
         """Check if the message contains inline LaTeX."""
-        for expression in constants.LATEX_RE.findall(message.content):
+        # Cap the number processed in a single message to 3 for now, to reduce spam.
+        for expression in constants.LATEX_RE.findall(message.content)[:3]:
             await self.latex(message.channel, expression)
 
     @command()


### PR DESCRIPTION
The LaTeX render should only trigger on the first three expressions in a message if this is merged. This is to try and reduce spamming from the bot if someone was to issue requests for multiple expressions at once. We may wish to consider additional measures to this, but for now this should help a little.