### PR TITLE
Add :someone command

### DIFF
--- a/cdbot/cogs/fun.py
+++ b/cdbot/cogs/fun.py
@@ -52,15 +52,15 @@ ascii_lowercase += " !?$()"
 
 REACT_TRIGGERS = {"kali": "\N{ONCOMING POLICE CAR}", "duck": "\N{DUCK}"}
 
-SOMEONE_EMOTES =[ u'\u0CA0_\u0CA0', 
-                u'\u30FD\u0F3C \u0CA0\u76CA\u0CA0 \u0F3D\uFF89', 
-                u'\u00AF(\u00B0_o)/\u00AF',
-                u'\uFF08\u273F \u0361\u25D5 \u1D17\u25D5)\u3064\u2501\u2501\u272B\u30FBo\u3002', 
-                u'(\u256F\u00B0\u25A1\u00B0\uFF09\u256F\uFE35 \u253B\u2501\u253B',
-                u'\uFF08\u273F \u0361\u25D5 \u1D17\u25D5)\u3064\u2501\u2501\u272B\u30FBo\u3002',
-                u'\u0F3C \u3064 \u25D5_\u25D5 \u0F3D\u3064',
-                u'(\u2229 \u0361\u00B0 \u035C\u0296 \u0361\u00B0)\u2283\u2501',
-                u'\u00AF\_(\u30C4)_/\u00AF ']
+SOMEONE_EMOTES = [u'\u0CA0_\u0CA0',
+                  u'\u30FD\u0F3C \u0CA0\u76CA\u0CA0 \u0F3D\uFF89', 
+                  u'\u00AF(\u00B0_o)/\u00AF',
+                  u'\uFF08\u273F \u0361\u25D5 \u1D17\u25D5)\u3064\u2501\u2501\u272B\u30FBo\u3002', 
+                  u'(\u256F\u00B0\u25A1\u00B0\uFF09\u256F\uFE35 \u253B\u2501\u253B',
+                  u'\uFF08\u273F \u0361\u25D5 \u1D17\u25D5)\u3064\u2501\u2501\u272B\u30FBo\u3002',
+                  u'\u0F3C \u3064 \u25D5_\u25D5 \u0F3D\u3064',
+                  u'(\u2229 \u0361\u00B0 \u035C\u0296 \u0361\u00B0)\u2283\u2501',
+                  u'\u00AF\_(\u30C4)_/\u00AF']
 
 def convert_emoji(message: str) -> List[str]:
     """Convert a string to a list of emojis."""
@@ -565,7 +565,7 @@ class Fun(Cog):
         """
         emote = choice(SOMEONE_EMOTES)
         user = choice(ctx.guild.members).display_name
-        response = u"@someone%s ***(%s)*** %s" % (emote, user, text)
+        response = u"@someone %s ***(%s)*** %s" % (emote, user, text)
         await ctx.send(response)
 
 def setup(bot):

--- a/cdbot/cogs/fun.py
+++ b/cdbot/cogs/fun.py
@@ -5,7 +5,7 @@ import asyncio
 import textwrap
 from io import BytesIO
 from math import ceil
-from random import randint
+from random import randint, choice
 from string import ascii_lowercase
 from typing import List
 from urllib.parse import urlencode
@@ -52,6 +52,15 @@ ascii_lowercase += " !?$()"
 
 REACT_TRIGGERS = {"kali": "\N{ONCOMING POLICE CAR}", "duck": "\N{DUCK}"}
 
+SOMEONE_EMOTES =[ u'\u0CA0_\u0CA0', 
+                u'\u30FD\u0F3C \u0CA0\u76CA\u0CA0 \u0F3D\uFF89', 
+                u'\u00AF(\u00B0_o)/\u00AF',
+                u'\uFF08\u273F \u0361\u25D5 \u1D17\u25D5)\u3064\u2501\u2501\u272B\u30FBo\u3002', 
+                u'(\u256F\u00B0\u25A1\u00B0\uFF09\u256F\uFE35 \u253B\u2501\u253B',
+                u'\uFF08\u273F \u0361\u25D5 \u1D17\u25D5)\u3064\u2501\u2501\u272B\u30FBo\u3002',
+                u'\u0F3C \u3064 \u25D5_\u25D5 \u0F3D\u3064',
+                u'(\u2229 \u0361\u00B0 \u035C\u0296 \u0361\u00B0)\u2283\u2501',
+                u'\u00AF\_(\u30C4)_/\u00AF ']
 
 def convert_emoji(message: str) -> List[str]:
     """Convert a string to a list of emojis."""
@@ -549,6 +558,15 @@ class Fun(Cog):
         """
         await self.create_text_image(ctx, "AngryLyne", text)
 
+    @command()
+    async def someone(self, ctx: Context, *, text: str)
+        """
+        Repeats the message but with a random member's name after :someone
+        """
+        emote = choice(SOMEONE_EMOTES)
+        user = choice(ctx.guild.members).display_name
+        response = u"@someone%s ***(%s)*** %s" % (emote, user, text)
+        await ctx.send(response)
 
 def setup(bot):
     """


### PR DESCRIPTION
Recreates Discord's April Fools @someone command. Example:
![image](https://user-images.githubusercontent.com/13556931/81113138-a694a280-8f17-11ea-8831-d3bc43904d43.png)
Currently chooses a random user from members, although this could be reworked to pull from online members, or those who have sent a message in the channel within the last n messages.