### PR TITLE
cyber.py - include information about VCS and Game

### DIFF
--- a/cdbot/cogs/cyber.py
+++ b/cdbot/cogs/cyber.py
@@ -56,7 +56,8 @@ class Cyber(Cog):
         ),
         (
             r"^.*\bgame\b.*\b(end|finish|close)\b.*$",
-            "CyberStart Game ends on the 31st May 2020.",
+            ("CyberStart Game ends on the 31st May 2020 for those participating in Year 3 of "
+            "Cyber Discovery, or the 31st August 2020 for those participating in the Virtual Cyber School."),
         ),
         # Essentials dates
         (

--- a/cdbot/cogs/cyber.py
+++ b/cdbot/cogs/cyber.py
@@ -56,8 +56,8 @@ class Cyber(Cog):
         ),
         (
             r"^.*\bgame\b.*\b(end|finish|close)\b.*$",
-            ("CyberStart Game ends on the 31st May 2020 for those participating in Year 3 of "
-            "Cyber Discovery, or the 31st August 2020 for those participating in the Virtual Cyber School."),
+            "CyberStart Game ends on the 31st May 2020 for those participating in Year 3 of "
+            "Cyber Discovery, or the 31st August 2020 for those participating in the Virtual Cyber School.",
         ),
         # Essentials dates
         (


### PR DESCRIPTION
The Virtual Cyber School's version of Game ends on the 31st of August, but the autoresponder just generically says that Game ends on the 31st of May. We aught to clarify this.