### PR TITLE
Fix one grammatical error.

### DIFF
--- a/cdbot/cogs/cyber.py
+++ b/cdbot/cogs/cyber.py
@@ -76,7 +76,7 @@ class Cyber(Cog):
         ),
         (
             r"^.*\belite\b.*\bstart\b.*$",
-            "CyberStart Elite Y3 will run throughout 27th July - 8th August. Y4 dates are yet to be announced",
+            "CyberStart Elite Y3 will run throughout 27th July - 8th August. Y4 dates are yet to be announced.",
         ),
         (
             r"^.*\bwhat\b.*\belite\b.*\bemail\b.*$",


### PR DESCRIPTION
Every time when i open up the CD server, and see elite dates, it pains me to see the last editors(probably Alphex's) lack of inclusion of a full stop. This revolutionary change will turn this:
CyberStart Elite Y3 will run throughout 27th July - 8th August. Y4 dates are yet to be announced
into this:
CyberStart Elite Y3 will run throughout 27th July - 8th August. Y4 dates are yet to be announced.

This will be a change of monumental proportions, which will steer the server to its amazing potential