### PR TITLE
Fix moon base alias

### DIFF
--- a/cdbot/constants.py
+++ b/cdbot/constants.py
@@ -141,7 +141,7 @@ END_README_MESSAGE = (
 BASE_ALIASES = {
     "Intern": ["intern", "i"],
     "Headquarters": ["headquarters", "main", "hq", "h"],
-    "Moonbase": ["moonbase", "python", "moon", "m"],
+    "Moon": ["moonbase", "python", "moon", "m"],
     "Forensics": ["forensics", "f"],
     "Volcano": ["volcano", "v", "volc"],
 }


### PR DESCRIPTION
Unsure how this slipped through. At some point `Moonbase` becamse `Moon` which broke the alias and therefore the `:l` command. This should fix that.

No I haven't tested this.
